### PR TITLE
Bumped compatible version of gnome-shell to 3.20

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -6,7 +6,7 @@
  "gettext-domain": "maximus",
  "description": "Undecorate maximized windows, like Ubuntu's old 'Maximus' package. See readme at extension homepage. Originally at https://bitbucket.org/mathematicalcoffee/maximus-gnome-shell-extension.",
  "shell-version": [
-     "3.18"
+     "3.20"
  ],
  "url": "https://github.com/luispabon/maximus-gnome-shell",
  "version": 11,


### PR DESCRIPTION
I've done a (very short, perhaps very incomplete) test of maximus on gnome-shell 3.20, and everything appears to be working correctly.

It'd be wonderful if we could put a new release on the gnome-extensions site.
