### PR TITLE
Added 3.18 version on metadata.json

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -6,7 +6,7 @@
  "gettext-domain": "maximus",
  "description": "Undecorate maximized windows, like Ubuntu's old 'Maximus' package. See readme at extension homepage. Originally at https://bitbucket.org/mathematicalcoffee/maximus-gnome-shell-extension.",
  "shell-version": [
-     "3.20"
+     "3.20", "3.18"
  ],
  "url": "https://github.com/luispabon/maximus-gnome-shell",
  "version": 11,

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -6,7 +6,8 @@
  "gettext-domain": "maximus",
  "description": "Undecorate maximized windows, like Ubuntu's old 'Maximus' package. See readme at extension homepage. Originally at https://bitbucket.org/mathematicalcoffee/maximus-gnome-shell-extension.",
  "shell-version": [
-     "3.20", "3.18"
+     "3.20", 
+     "3.18"
  ],
  "url": "https://github.com/luispabon/maximus-gnome-shell",
  "version": 11,


### PR DESCRIPTION
I tested this extension on Gnome 3.18 and it works beautifully. So I added 3.18 version on metadata.json.
